### PR TITLE
Fix session cookies not persisted after 2FA trust step

### DIFF
--- a/Sources/xcodeinstall/API/Authentication+MFA.swift
+++ b/Sources/xcodeinstall/API/Authentication+MFA.swift
@@ -319,6 +319,12 @@ extension AppleAuthenticator {
         if let newScnt = response.value(forHTTPHeaderField: "scnt") {
             session.scnt = newScnt
         }
+
+        // The trust response carries the long-lived session cookies that subsequent
+        // commands need. Without saving them here, the next command fails with
+        // "session expired" because only the verification response (which may lack
+        // cookies) was being persisted.
+        try await self.saveSession(response: response, session: session)
     }
 
     func getMFAType() async throws -> MFAType {

--- a/Sources/xcodeinstall/API/Authentication+MFA.swift
+++ b/Sources/xcodeinstall/API/Authentication+MFA.swift
@@ -241,7 +241,6 @@ extension AppleAuthenticator {
             }
         case 200, 204:
             try await trustSession()
-            try await self.saveSession(response: response, session: session)
         default:
             throw AuthenticationError.unexpectedHTTPReturnCode(code: response.statusCode)
         }
@@ -291,7 +290,6 @@ extension AppleAuthenticator {
         case 200, 204:
             // success
             try await trustSession()
-            try await self.saveSession(response: response, session: session)
 
         default:
             // unknown error, fail gracefully

--- a/Tests/xcodeinstallTests/API/AuthenticationMFATest.swift
+++ b/Tests/xcodeinstallTests/API/AuthenticationMFATest.swift
@@ -492,4 +492,93 @@ extension AuthenticationTests {
         }
         #expect(error == AuthenticationError.unexpectedHTTPReturnCode(code: 300))
     }
+
+    // MARK: - Trust Session Cookie Persistence Tests
+
+    @Test("trustSession saves cookies from trust response")
+    func testTrustSessionSavesCookies() async {
+        let url = "https://dummy"
+        let trustCookies = "myacinfo=TRUST_TOKEN; Domain=apple.com; Path=/; Secure; HttpOnly"
+
+        let trustResponse = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Set-Cookie": trustCookies]
+        )!
+
+        self.sessionData.enqueueResponse(data: Data(), response: trustResponse)
+
+        let authenticator = getAppleAuthenticator()
+        authenticator.session = getAppleSession()
+
+        try! await authenticator.trustSession()
+
+        let secrets = env.secrets as! MockedSecretsHandler
+        #expect(secrets.savedCookies.contains(trustCookies))
+    }
+
+    @Test("2FA trusted device saves cookies from trust response")
+    func testTwoFactorAuthenticationSavesTrustCookies() async {
+        let url = "https://dummy"
+        let trustCookies = "myacinfo=TRUST_TOKEN; Domain=apple.com; Path=/; Secure; HttpOnly"
+
+        // First response: 2FA verification succeeds (no cookies)
+        let verifyResponse = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        self.sessionData.enqueueResponse(data: Data(), response: verifyResponse)
+
+        // Second response: trust step returns long-lived cookies
+        let trustResponse = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Set-Cookie": trustCookies]
+        )!
+        self.sessionData.enqueueResponse(data: Data(), response: trustResponse)
+
+        let authenticator = getAppleAuthenticator()
+        authenticator.session = getAppleSession()
+
+        try! await authenticator.twoFactorAuthentication(pin: "123456")
+
+        let secrets = env.secrets as! MockedSecretsHandler
+        #expect(secrets.savedCookies.contains(trustCookies))
+    }
+
+    @Test("SMS verification saves cookies from trust response")
+    func testVerifySMSCodeSavesTrustCookies() async {
+        let url = "https://dummy"
+        let trustCookies = "myacinfo=TRUST_TOKEN; Domain=apple.com; Path=/; Secure; HttpOnly"
+
+        // First response: SMS verification succeeds (no cookies)
+        let verifyResponse = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        self.sessionData.enqueueResponse(data: Data(), response: verifyResponse)
+
+        // Second response: trust step returns long-lived cookies
+        let trustResponse = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Set-Cookie": trustCookies]
+        )!
+        self.sessionData.enqueueResponse(data: Data(), response: trustResponse)
+
+        let authenticator = getAppleAuthenticator()
+        authenticator.session = getAppleSession()
+
+        try! await authenticator.verifySMSCode("123456", phoneId: 2)
+
+        let secrets = env.secrets as! MockedSecretsHandler
+        #expect(secrets.savedCookies.contains(trustCookies))
+    }
 }

--- a/Tests/xcodeinstallTests/API/MockedNetworkClasses.swift
+++ b/Tests/xcodeinstallTests/API/MockedNetworkClasses.swift
@@ -21,24 +21,37 @@ final class MockedURLSession: URLSessionProtocol {
     let log = Logger(label: "MockedURLSession")
     private(set) var lastURL: URL?
     private(set) var lastRequest: URLRequest?
+    private(set) var allRequests: [URLRequest] = []
 
     var nextData: Data?
     var nextError: Error?
     var nextResponse: URLResponse?
 
+    private var responseQueue: [(data: Data, response: URLResponse)] = []
+
+    func enqueueResponse(data: Data, response: URLResponse) {
+        responseQueue.append((data: data, response: response))
+    }
+
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
+
+        lastURL = request.url
+        lastRequest = request
+        allRequests.append(request)
+
+        if nextError != nil {
+            throw nextError!
+        }
+
+        if !responseQueue.isEmpty {
+            let queued = responseQueue.removeFirst()
+            return (queued.data, queued.response)
+        }
 
         guard let data = nextData,
             let response = nextResponse
         else {
             throw MockError.invalidMockData
-        }
-
-        lastURL = request.url
-        lastRequest = request
-
-        if nextError != nil {
-            throw nextError!
         }
 
         return (data, response)

--- a/Tests/xcodeinstallTests/Secrets/MockedSecretsHandler.swift
+++ b/Tests/xcodeinstallTests/Secrets/MockedSecretsHandler.swift
@@ -39,8 +39,13 @@ final class MockedSecretsHandler: SecretsHandlerProtocol {
 
     }
 
+    private(set) var savedCookies: [String] = []
+
     func saveCookies(_ cookies: String?) async throws -> String? {
-        ""
+        if let cookies {
+            savedCookies.append(cookies)
+        }
+        return cookies
     }
 
     func loadCookies() async throws -> [HTTPCookie] {


### PR DESCRIPTION
## Summary

- After 2FA verification, `trustSession()` calls Apple's `/auth/2sv/trust` endpoint which returns long-lived session cookies. These were never saved to disk, causing the next command to fail with "Session expired, you need to re-authenticate."
- Added `saveSession(response:session:)` call at the end of `trustSession()` so the upgraded cookies are persisted immediately.

Fixes #132

## Test plan

- [ ] Authenticate with 2FA (trusted device), then immediately run `download` or `list` — should succeed without re-authentication
- [ ] Authenticate with SMS 2FA, then immediately run `download` or `list` — should succeed
- [ ] Verify `swift test` passes (175 tests pass locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)