### PR TITLE
Add pre-flight sudoers check before install

### DIFF
--- a/Sources/xcodeinstall/API/Install.swift
+++ b/Sources/xcodeinstall/API/Install.swift
@@ -71,6 +71,40 @@ class ShellInstaller {
         "MobileDeviceDevelopment.pkg",
     ]
 
+    /// Check whether the current user can run sudo without a password prompt.
+    /// If not, log a warning with instructions on how to configure passwordless sudo.
+    /// This check warns but does not abort — the user might still enter their password interactively.
+    func checkSudoersConfiguration() async {
+        let username = ProcessInfo.processInfo.userName
+
+        do {
+            let result = try await self.shellExecutor.run(
+                .path(SUDOCOMMAND),
+                arguments: ["-n", "true"]
+            )
+            if !result.terminationStatus.isSuccess {
+                logSudoersWarning(username: username)
+            }
+        } catch {
+            logSudoersWarning(username: username)
+        }
+    }
+
+    private func logSudoersWarning(username: String) {
+        log.warning(
+            """
+            Passwordless sudo is not configured for user '\(username)'.
+            The install command requires sudo to run the system installer.
+            You may be prompted for your password during installation.
+
+            To enable passwordless sudo, create the file /etc/sudoers.d/\(username) with:
+              \(username) ALL=(ALL) NOPASSWD: ALL
+
+            Run: sudo sh -c 'echo "\(username) ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/\(username)'
+            """
+        )
+    }
+
     /// Install Xcode or Xcode Command Line Tools
     ///  At this stage, we do support only these two installation.
     ///

--- a/Sources/xcodeinstall/API/Install.swift
+++ b/Sources/xcodeinstall/API/Install.swift
@@ -98,9 +98,9 @@ class ShellInstaller {
             You may be prompted for your password during installation.
 
             To enable passwordless sudo, create the file /etc/sudoers.d/\(username) with:
-              \(username) ALL=(ALL) NOPASSWD: ALL
+              \(username) ALL=(ALL) NOPASSWD: /usr/sbin/installer, /usr/bin/hdiutil
 
-            Run: sudo sh -c 'echo "\(username) ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/\(username)'
+            Run: sudo sh -c 'echo "\(username) ALL=(ALL) NOPASSWD: /usr/sbin/installer, /usr/bin/hdiutil" > /etc/sudoers.d/\(username)'
             """
         )
     }

--- a/Sources/xcodeinstall/xcodeInstall/InstallCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/InstallCommand.swift
@@ -22,6 +22,9 @@ extension XCodeInstall {
             log: self.log
         )
 
+        // check if passwordless sudo is available before starting installation
+        await installer.checkSudoersConfiguration()
+
         // progress bar to report progress feedback
         let progressBar = self.deps.progressBar
         progressBar.define(

--- a/Tests/xcodeinstallTests/API/InstallTest.swift
+++ b/Tests/xcodeinstallTests/API/InstallTest.swift
@@ -61,6 +61,26 @@ final class InstallTest {
 
     }
 
+    @Test("Test Check Sudoers Configuration Runs Sudo Non-Interactive")
+    func testCheckSudoersConfiguration() async throws {
+        // given
+        let installer = ShellInstaller(
+            fileHandler: self.env.fileHandler,
+            progressBar: self.env.progressBar,
+            shellExecutor: self.env.shell,
+            log: self.log
+        )
+
+        // when
+        await installer.checkSudoersConfiguration()
+
+        // then — verify that `sudo -n true` was invoked
+        let runRecorder = MockedShell.runRecorder
+        #expect(runRecorder.containsExecutable("/usr/bin/sudo"))
+        #expect(runRecorder.containsArgument("-n"))
+        #expect(runRecorder.containsArgument("true"))
+    }
+
     @Test("Test Install Pkg Uses Sudo")
     func testInstallPkgUsesSudo() async throws {
         // given


### PR DESCRIPTION
## Summary

- Runs `sudo -n true` before starting installation to detect whether passwordless sudo is configured
- If not, logs a warning with instructions for creating `/etc/sudoers.d/<username>` with a `NOPASSWD` rule
- The check warns but does not abort — users can still enter their password interactively

Closes #22

## Test plan

- [x] Run `sudo -k` then `xcodeinstall install` — should see the warning
- [x] Configure `/etc/sudoers.d/<user>` with `NOPASSWD` rule, then `sudo -k` and `xcodeinstall install` — no warning
- [x] `swift test` passes (179 tests, including new `testCheckSudoersConfiguration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)