### PR TITLE
fix: report each error once, from a single presenter

### DIFF
--- a/Sources/xcodeinstall/API/Install.swift
+++ b/Sources/xcodeinstall/API/Install.swift
@@ -23,6 +23,7 @@ enum InstallerError: Error, Equatable {
     case xCodePKGInstallationError
     case CLToolsInstallationError
     case xcodeSelectFailed
+    case unableToListInstalledXcodes
     case noInstalledXcodeVersions
     case xcodeVersionNotInstalled(String)
     case existingXcodeAppIsNotSymlink

--- a/Sources/xcodeinstall/CLI-driver/CLIAuthenticate.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIAuthenticate.swift
@@ -32,29 +32,16 @@ extension MainCommand {
 
         func run(with deps: AppDependencies?) async throws {
 
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    for: cloudOption.secretManagerRegion,
-                    profileName: cloudOption.profileName,
-                    verbose: globalOptions.verbose,
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                for: cloudOption.secretManagerRegion,
+                profileName: cloudOption.profileName,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 try await xci.authenticate(with: AuthenticationMethod.withSRP(srp))
-            } catch {
-                try? await xci.deps.secrets?.shutdown()
-                throw ExitCode.failure
             }
-
-            // Gracefully shut down AWS client before process exits
-            // to avoid RotatingCredentialProvider crash during deallocation
-            try? await xci.deps.secrets?.shutdown()
         }
     }
 
@@ -70,29 +57,16 @@ extension MainCommand {
 
         func run(with deps: AppDependencies?) async throws {
 
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    for: cloudOption.secretManagerRegion,
-                    profileName: cloudOption.profileName,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                for: cloudOption.secretManagerRegion,
+                profileName: cloudOption.profileName,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 try await xci.signout()
-            } catch {
-                try? await xci.deps.secrets?.shutdown()
-                throw ExitCode.failure
             }
-
-            // Gracefully shut down AWS client before process exits
-            // to avoid RotatingCredentialProvider crash during deallocation
-            try? await xci.deps.secrets?.shutdown()
         }
     }
 

--- a/Sources/xcodeinstall/CLI-driver/CLIDownload.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIDownload.swift
@@ -37,20 +37,14 @@ extension MainCommand {
         }
 
         func run(with deps: AppDependencies?) async throws {
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    for: cloudOption.secretManagerRegion,
-                    profileName: cloudOption.profileName,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                for: cloudOption.secretManagerRegion,
+                profileName: cloudOption.profileName,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 try await xci.download(
                     fileName: name,
                     force: downloadListOptions.force,
@@ -59,14 +53,7 @@ extension MainCommand {
                     sortMostRecentFirst: downloadListOptions.mostRecentFirst,
                     datePublished: downloadListOptions.datePublished
                 )
-            } catch {
-                try? await xci.deps.secrets?.shutdown()
-                throw ExitCode.failure
             }
-
-            // Gracefully shut down AWS client before process exits
-            // to avoid RotatingCredentialProvider crash during deallocation
-            try? await xci.deps.secrets?.shutdown()
         }
     }
 

--- a/Sources/xcodeinstall/CLI-driver/CLIErrorPresentation.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIErrorPresentation.swift
@@ -1,0 +1,87 @@
+//
+//  CLIErrorPresentation.swift
+//  xcodeinstall
+//
+//  The one place where a subcommand turns an error into output and an exit code.
+//
+
+import ArgumentParser
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension MainCommand {
+
+    /// Builds the `XCodeInstall` facade, reporting a construction failure to the user.
+    ///
+    /// Construction happens before the dependencies exist, so the error is displayed on a
+    /// freshly built `NooraDisplay` rather than on `xci.deps.display`.
+    static func makeXCodeInstall(
+        with deps: AppDependencies?,
+        for region: String? = nil,
+        profileName: String? = nil,
+        verbose: Bool
+    ) async throws -> XCodeInstall {
+        do {
+            return try await XCodeInstaller(
+                with: deps,
+                for: region,
+                profileName: profileName,
+                verbose: verbose
+            )
+        } catch {
+            await presentOnTerminal(error)
+            throw ExitCode.failure
+        }
+    }
+
+    /// Runs the body of a subcommand, displaying any error exactly once and mapping it
+    /// to the process exit code.
+    ///
+    /// The `XCodeInstall` layer only throws — this is the single place where errors
+    /// become output, which is what keeps a nested failure (`download` → `list`) from
+    /// being reported twice.
+    static func run(on xci: XCodeInstall, _ body: () async throws -> Void) async throws {
+        do {
+            try await body()
+        } catch {
+            let presentation = await present(error, for: xci)
+
+            // Gracefully shut down AWS client before process exits
+            // to avoid RotatingCredentialProvider crash during deallocation
+            try? await xci.deps.secrets?.shutdown()
+
+            guard presentation.isFailure else { return }
+            throw ExitCode.failure
+        }
+
+        // Gracefully shut down AWS client before process exits
+        // to avoid RotatingCredentialProvider crash during deallocation
+        try? await xci.deps.secrets?.shutdown()
+    }
+
+    // MARK: - Rendering
+
+    @MainActor
+    private static func present(_ error: Error, for xci: XCodeInstall) -> ErrorPresentation {
+        present(error, on: xci.deps.display)
+    }
+
+    @MainActor
+    private static func presentOnTerminal(_ error: Error) {
+        present(error, on: NooraDisplay())
+    }
+
+    @MainActor
+    @discardableResult
+    private static func present(_ error: Error, on display: DisplayProtocol) -> ErrorPresentation {
+        let presentation = ErrorPresenter.presentation(for: error)
+        for message in presentation.messages {
+            display.display(message.text, style: message.style)
+        }
+        return presentation
+    }
+}

--- a/Sources/xcodeinstall/CLI-driver/CLIInstall.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIInstall.swift
@@ -41,21 +41,13 @@ extension MainCommand {
         }
 
         func run(with deps: AppDependencies?) async throws {
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 try await xci.install(file: name, version: xcodeVersion)
-            } catch {
-                throw ExitCode.failure
             }
         }
     }

--- a/Sources/xcodeinstall/CLI-driver/CLIList.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIList.swift
@@ -63,20 +63,14 @@ extension MainCommand {
         }
 
         func run(with deps: AppDependencies?) async throws {
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    for: cloudOption.secretManagerRegion,
-                    profileName: cloudOption.profileName,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                for: cloudOption.secretManagerRegion,
+                profileName: cloudOption.profileName,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 _ = try await xci.list(
                     force: downloadListOptions.force,
                     xCodeOnly: downloadListOptions.onlyXcode,
@@ -84,14 +78,7 @@ extension MainCommand {
                     sortMostRecentFirst: downloadListOptions.mostRecentFirst,
                     datePublished: downloadListOptions.datePublished
                 )
-            } catch {
-                try? await xci.deps.secrets?.shutdown()
-                throw ExitCode.failure
             }
-
-            // Gracefully shut down AWS client before process exits
-            // to avoid RotatingCredentialProvider crash during deallocation
-            try? await xci.deps.secrets?.shutdown()
         }
     }
 }

--- a/Sources/xcodeinstall/CLI-driver/CLIStoreSecrets.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLIStoreSecrets.swift
@@ -43,29 +43,16 @@ extension MainCommand {
         }
 
         func run(with deps: AppDependencies?) async throws {
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    for: secretManagerRegion,
-                    profileName: profileName,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                for: secretManagerRegion,
+                profileName: profileName,
+                verbose: globalOptions.verbose
+            )
 
-            do {
-                _ = try await xci.storeSecrets()
-            } catch {
-                try? await xci.deps.secrets?.shutdown()
-                throw ExitCode.failure
+            try await MainCommand.run(on: xci) {
+                try await xci.storeSecrets()
             }
-
-            // Gracefully shut down AWS client before process exits
-            // to avoid RotatingCredentialProvider crash during deallocation
-            try? await xci.deps.secrets?.shutdown()
         }
     }
 

--- a/Sources/xcodeinstall/CLI-driver/CLISwitch.swift
+++ b/Sources/xcodeinstall/CLI-driver/CLISwitch.swift
@@ -29,21 +29,13 @@ extension MainCommand {
         }
 
         func run(with deps: AppDependencies?) async throws {
-            let xci: XCodeInstall
-            do {
-                xci = try await MainCommand.XCodeInstaller(
-                    with: deps,
-                    verbose: globalOptions.verbose
-                )
-            } catch {
-                await NooraDisplay().display(error.localizedDescription, terminator: "\n", style: .error())
-                throw ExitCode.failure
-            }
+            let xci = try await MainCommand.makeXCodeInstall(
+                with: deps,
+                verbose: globalOptions.verbose
+            )
 
-            do {
+            try await MainCommand.run(on: xci) {
                 try await xci.switchVersion(to: version)
-            } catch {
-                throw ExitCode.failure
             }
         }
     }

--- a/Sources/xcodeinstall/CLI/ErrorPresenter.swift
+++ b/Sources/xcodeinstall/CLI/ErrorPresenter.swift
@@ -148,16 +148,27 @@ enum ErrorPresenter {
         }
     }
 
+    /// Exhaustive on purpose: a new installation failure must come with the message
+    /// the user will read, and the compiler is the reminder.
     private static func presentation(for error: InstallerError) -> ErrorPresentation {
         switch error {
         case .unsupportedInstallation:
             return .failure("Unsupported installation type. (We support Xcode XIP files and Command Line Tools PKG)")
+        case .fileDoesNotExistOrIncorrect:
+            return .failure(
+                "The file to install does not exist, or its size does not match the one announced by Apple.",
+                style: .error(nextSteps: ["xcodeinstall download"])
+            )
+        case .xCodeUnxipDirectoryDoesntExist:
+            return .failure("Can not find the directory where Xcode was expanded")
         case .xCodeXIPInstallationError:
             return .failure("Can not expand XIP file. Is there enough space on / ? (16GiB required)")
         case .xCodeMoveInstallationError:
             return .failure("Can not move Xcode to /Applications")
         case .xCodePKGInstallationError:
             return .failure("Can not install additional packages.")
+        case .CLToolsInstallationError:
+            return .failure("Can not install the Xcode Command Line Tools")
         case .existingXcodeAppIsNotSymlink:
             return .failure(
                 "/Applications/Xcode.app exists and is not a symlink. Please rename or remove it before installing a versioned Xcode."
@@ -170,8 +181,6 @@ enum ErrorPresenter {
             return .failure("No versioned Xcode installations found in /Applications", style: .warning)
         case .xcodeVersionNotInstalled(let version):
             return .failure("Xcode \(version) is not installed in /Applications")
-        default:
-            return .failure(unexpected(error))
         }
     }
 

--- a/Sources/xcodeinstall/CLI/ErrorPresenter.swift
+++ b/Sources/xcodeinstall/CLI/ErrorPresenter.swift
@@ -1,0 +1,198 @@
+//
+//  ErrorPresenter.swift
+//  xcodeinstall
+//
+//  Single point of translation between errors and user-facing output.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// The user-facing rendering of an error: what to display, and whether the
+/// process must terminate with a failure.
+struct ErrorPresentation {
+
+    struct Message {
+        let text: String
+        let style: DisplayStyle
+    }
+
+    /// The messages to display, in order. Empty when the error must stay silent.
+    let messages: [Message]
+
+    /// `true` when the process must terminate with a failure exit code.
+    let isFailure: Bool
+}
+
+extension ErrorPresentation {
+
+    /// Nothing to display and no failure: the user deliberately interrupted the command.
+    static let silent = ErrorPresentation(messages: [], isFailure: false)
+
+    static func failure(_ text: String, style: DisplayStyle = .error()) -> ErrorPresentation {
+        ErrorPresentation(messages: [Message(text: text, style: style)], isFailure: true)
+    }
+
+    static func failure(_ messages: Message...) -> ErrorPresentation {
+        ErrorPresentation(messages: messages, isFailure: true)
+    }
+}
+
+/// Turns any error thrown by the business logic into the text the user sees.
+///
+/// The `XCodeInstall` layer only throws, it never renders errors. The CLI layer
+/// (`MainCommand`) calls this presenter from a single place per subcommand. As a
+/// result an error is rendered exactly once, whichever code path produced it —
+/// including errors that bubble up through a nested command, such as `download`
+/// asking `list` for the list of available files.
+enum ErrorPresenter {
+
+    private static let bugReportURL =
+        "https://github.com/sebsto/xcodeinstall/issues/new?assignees=&labels=&template=bug_report.md&title="
+
+    static func presentation(for error: Error) -> ErrorPresentation {
+        switch error {
+        case let error as CLIError:
+            return presentation(for: error)
+        case let error as DownloadError:
+            return presentation(for: error)
+        case let error as AuthenticationError:
+            return presentation(for: error)
+        case let error as InstallerError:
+            return presentation(for: error)
+        case let error as FileHandlerError:
+            return presentation(for: error)
+        case let error as SecretsStorageAWSError:
+            return .failure("AWS Error: \(error.localizedDescription)")
+        default:
+            return .failure(unexpected(error))
+        }
+    }
+
+    // MARK: - Per error type
+
+    private static func presentation(for error: CLIError) -> ErrorPresentation {
+        switch error {
+        case .userCancelled:
+            // the user pressed enter on a prompt, there is nothing to report
+            return .silent
+        case .invalidInput:
+            return .failure("Invalid input")
+        }
+    }
+
+    private static func presentation(for error: DownloadError) -> ErrorPresentation {
+        switch error {
+        case .authenticationRequired:
+            return .failure(
+                "Session expired, you need to re-authenticate.",
+                style: .error(nextSteps: ["xcodeinstall authenticate"])
+            )
+        case .unknownFile(let file):
+            return .failure("Unknown file name : \(file)")
+        case .accountNeedUpgrade(let errorCode, let errorMessage):
+            return .failure("\(errorMessage) (Apple Portal error code : \(errorCode))")
+        case .needToAcceptTermsAndCondition:
+            return .failure(
+                """
+                This is a new Apple account, you need first to accept the developer terms of service.
+                Open a session at https://developer.apple.com/register/agree/
+                Read and accept the ToS and try again.
+                """
+            )
+        case .unknownError(let errorCode, let errorMessage):
+            return .failure(
+                Message(text: "\(errorMessage) (Unhandled download error : \(errorCode))", style: .error()),
+                bugReportMessage
+            )
+        default:
+            return .failure(
+                Message(text: "Unknown download error : \(error)", style: .error()),
+                bugReportMessage
+            )
+        }
+    }
+
+    private static func presentation(for error: AuthenticationError) -> ErrorPresentation {
+        switch error {
+        case .invalidUsernamePassword:
+            return .failure("Invalid username or password.")
+        case .requires2FATrustedPhoneNumber:
+            return .failure(
+                """
+                Two factors authentication is enabled but no verification methods are available.
+                Please ensure you have trusted devices or phone numbers configured:
+                https://support.apple.com/en-us/HT204915
+                """,
+                style: .security
+            )
+        case .serviceUnavailable:
+            // the authentication method requested is not available
+            return .failure("Requested authentication method is not available. Try with SRP.")
+        case .unableToRetrieveAppleServiceKey(let underlyingError):
+            return .failure(
+                """
+                Can not connect to Apple Developer Portal.
+                Original error : \(underlyingError?.localizedDescription ?? "nil")
+                """
+            )
+        case .notImplemented(let featureName):
+            return .failure(
+                "\(featureName) is not yet implemented. Try the next version of xcodeinstall when it will be available."
+            )
+        default:
+            return .failure(unexpected(error))
+        }
+    }
+
+    private static func presentation(for error: InstallerError) -> ErrorPresentation {
+        switch error {
+        case .unsupportedInstallation:
+            return .failure("Unsupported installation type. (We support Xcode XIP files and Command Line Tools PKG)")
+        case .xCodeXIPInstallationError:
+            return .failure("Can not expand XIP file. Is there enough space on / ? (16GiB required)")
+        case .xCodeMoveInstallationError:
+            return .failure("Can not move Xcode to /Applications")
+        case .xCodePKGInstallationError:
+            return .failure("Can not install additional packages.")
+        case .existingXcodeAppIsNotSymlink:
+            return .failure(
+                "/Applications/Xcode.app exists and is not a symlink. Please rename or remove it before installing a versioned Xcode."
+            )
+        case .xcodeSelectFailed:
+            return .failure("Failed to run xcode-select to activate Xcode")
+        case .unableToListInstalledXcodes:
+            return .failure("Failed to list installed Xcode versions")
+        case .noInstalledXcodeVersions:
+            return .failure("No versioned Xcode installations found in /Applications", style: .warning)
+        case .xcodeVersionNotInstalled(let version):
+            return .failure("Xcode \(version) is not installed in /Applications")
+        default:
+            return .failure(unexpected(error))
+        }
+    }
+
+    private static func presentation(for error: FileHandlerError) -> ErrorPresentation {
+        switch error {
+        case .noDownloadedList:
+            return .failure("There is no downloaded file to be installed", style: .warning)
+        case .fileDoesNotExist:
+            return .failure(unexpected(error))
+        }
+    }
+
+    // MARK: - Shared messages
+
+    private static var bugReportMessage: ErrorPresentation.Message {
+        Message(text: "Please file an error report at \(bugReportURL)", style: .normal)
+    }
+
+    private static func unexpected(_ error: Error) -> String {
+        "Unexpected error : \(error)"
+    }
+}
+
+private typealias Message = ErrorPresentation.Message

--- a/Sources/xcodeinstall/xcodeInstall/AuthenticateCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/AuthenticateCommand.swift
@@ -188,74 +188,25 @@ struct CLIAuthenticationDelegate: AuthenticationDelegate, Sendable {
 
 extension XCodeInstall {
 
+    /// Authenticates against the Apple Developer Portal.
+    ///
+    /// Errors are propagated untouched, the CLI layer renders them once
+    /// (see `ErrorPresenter`).
     func authenticate(with authenticationMethod: AuthenticationMethod) async throws {
 
         let auth = self.deps.authenticator
         let delegate = CLIAuthenticationDelegate(deps: self.deps)
 
-        do {
+        // delete previous session, if any
+        try await self.deps.secrets?.clearSecrets()
 
-            // delete previous session, if any
-            try await self.deps.secrets?.clearSecrets()
-
-            if authenticationMethod == .usernamePassword {
-                display("Authenticating with username and password (likely to fail) ...")
-            } else {
-                display("Authenticating...")
-            }
-            try await auth.authenticate(with: authenticationMethod, delegate: delegate)
-            display("Authenticated.", style: .success)
-
-        } catch AuthenticationError.invalidUsernamePassword {
-
-            // handle invalid username or password
-            display("Invalid username or password.", style: .error())
-            throw AuthenticationError.invalidUsernamePassword
-
-        } catch AuthenticationError.requires2FATrustedPhoneNumber {
-
-            display(
-                """
-                Two factors authentication is enabled but no verification methods are available.
-                Please ensure you have trusted devices or phone numbers configured:
-                https://support.apple.com/en-us/HT204915
-                """,
-                style: .security
-            )
-            throw AuthenticationError.requires2FATrustedPhoneNumber
-
-        } catch AuthenticationError.serviceUnavailable {
-
-            // service unavailable means that the authentication method requested is not available
-            display("Requested authentication method is not available. Try with SRP.", style: .error())
-            throw AuthenticationError.serviceUnavailable
-
-        } catch AuthenticationError.unableToRetrieveAppleServiceKey(let error) {
-
-            // handle connection errors
-            display(
-                "Can not connect to Apple Developer Portal.\nOriginal error : \(error?.localizedDescription ?? "nil")",
-                style: .error()
-            )
-            throw AuthenticationError.unableToRetrieveAppleServiceKey(error)
-
-        } catch AuthenticationError.notImplemented(let feature) {
-
-            // handle not yet implemented errors
-            display(
-                "\(feature) is not yet implemented. Try the next version of xcodeinstall when it will be available.",
-                style: .error()
-            )
-            throw AuthenticationError.notImplemented(featureName: feature)
-
-        } catch let error as SecretsStorageAWSError {
-            display("AWS Error: \(error.localizedDescription)", style: .error())
-            throw error
-
-        } catch {
-            display("Unexpected Error : \(error)", style: .error())
-            throw error
+        if authenticationMethod == .usernamePassword {
+            display("Authenticating with username and password (likely to fail) ...")
+        } else {
+            display("Authenticating...")
         }
+        try await auth.authenticate(with: authenticationMethod, delegate: delegate)
+        display("Authenticated.", style: .success)
     }
 
 }

--- a/Sources/xcodeinstall/xcodeInstall/DownloadCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/DownloadCommand.swift
@@ -13,6 +13,10 @@ import Foundation
 
 extension XCodeInstall {
 
+    /// Downloads a file, asking the user which one when `fileName` is `nil`.
+    ///
+    /// Errors are propagated untouched, the CLI layer renders them once
+    /// (see `ErrorPresenter`).
     // swiftlint:disable: function_parameter_count
     func download(
         fileName: String?,
@@ -24,82 +28,60 @@ extension XCodeInstall {
     ) async throws {
 
         let download = self.deps.downloader
-        var fileToDownload: DownloadList.File
-        do {
+        let fileToDownload: DownloadList.File
 
-            // when filename was given by user
-            if fileName != nil {
+        // when filename was given by user
+        if fileName != nil {
 
-                // search matching filename in the download list cache
-                let (list, _) = try await download.list(force: force)
-                if let result = list.find(fileName: fileName!) {
-                    fileToDownload = result
-                } else {
-                    throw DownloadError.unknownFile(file: fileName!)
-                }
-
+            // search matching filename in the download list cache
+            let (list, _) = try await download.list(force: force)
+            if let result = list.find(fileName: fileName!) {
+                fileToDownload = result
             } else {
-
-                // when no file was given, ask user
-                fileToDownload = try await self.askFile(
-                    force: force,
-                    xCodeOnly: xCodeOnly,
-                    majorVersion: majorVersion,
-                    sortMostRecentFirst: sortMostRecentFirst,
-                    datePublished: datePublished
-                )
+                throw DownloadError.unknownFile(file: fileName!)
             }
 
-            // now we have a filename, let's proceed with download
-            let progressBar = self.deps.progressBar
-            progressBar.define(
-                animationType: .percentProgressAnimation,
-                message: "Downloading \(fileToDownload.displayName ?? fileToDownload.filename)"
-            )
+        } else {
 
-            for try await progress in try await download.download(file: fileToDownload) {
-                var text = "\(progress.bytesWritten/1024/1024) MB"
-                text += String(format: " / %.2f MBs", progress.bandwidth)
-                progressBar.update(
-                    step: Int(progress.bytesWritten / 1024),
-                    total: Int(progress.totalBytes / 1024),
-                    text: text
-                )
-            }
-            progressBar.complete(success: true)
+            // when no file was given, ask user
+            fileToDownload = try await self.askFile(
+                force: force,
+                xCodeOnly: xCodeOnly,
+                majorVersion: majorVersion,
+                sortMostRecentFirst: sortMostRecentFirst,
+                datePublished: datePublished
+            )
+        }
 
-            // check if the downloaded file is complete
-            let fh = self.deps.fileHandler
-            let file: URL = await fh.downloadFileURL(file: fileToDownload)
-            let complete = try? self.deps.fileHandler.checkFileSize(
-                file: file,
-                fileSize: fileToDownload.fileSize
+        // now we have a filename, let's proceed with download
+        let progressBar = self.deps.progressBar
+        progressBar.define(
+            animationType: .percentProgressAnimation,
+            message: "Downloading \(fileToDownload.displayName ?? fileToDownload.filename)"
+        )
+
+        for try await progress in try await download.download(file: fileToDownload) {
+            var text = "\(progress.bytesWritten/1024/1024) MB"
+            text += String(format: " / %.2f MBs", progress.bandwidth)
+            progressBar.update(
+                step: Int(progress.bytesWritten / 1024),
+                total: Int(progress.totalBytes / 1024),
+                text: text
             )
-            if !(complete ?? false) {
-                display("Downloaded file has incorrect size, it might be incomplete or corrupted", style: .error())
-            } else {
-                display("\(fileName ?? "file") downloaded", style: .success)
-            }
-        } catch DownloadError.authenticationRequired {
-            display(
-                "Session expired, you need to re-authenticate.",
-                style: .error(nextSteps: ["xcodeinstall authenticate"])
-            )
-            throw DownloadError.authenticationRequired
-        } catch CLIError.userCancelled {
-            return
-        } catch CLIError.invalidInput {
-            display("Invalid input", style: .error())
-            throw CLIError.invalidInput
-        } catch DownloadError.unknownFile(let fileName) {
-            display("Unknown file name : \(fileName)", style: .error())
-            throw DownloadError.unknownFile(file: fileName)
-        } catch let error as SecretsStorageAWSError {
-            display("AWS Error: \(error.localizedDescription)", style: .error())
-            throw error
-        } catch {
-            display("Unexpected error : \(error)", style: .error())
-            throw error
+        }
+        progressBar.complete(success: true)
+
+        // check if the downloaded file is complete
+        let fh = self.deps.fileHandler
+        let file: URL = await fh.downloadFileURL(file: fileToDownload)
+        let complete = try? self.deps.fileHandler.checkFileSize(
+            file: file,
+            fileSize: fileToDownload.fileSize
+        )
+        if !(complete ?? false) {
+            display("Downloaded file has incorrect size, it might be incomplete or corrupted", style: .error())
+        } else {
+            display("\(fileName ?? "file") downloaded", style: .success)
         }
     }
 

--- a/Sources/xcodeinstall/xcodeInstall/DownloadCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/DownloadCommand.swift
@@ -60,16 +60,25 @@ extension XCodeInstall {
             message: "Downloading \(fileToDownload.displayName ?? fileToDownload.filename)"
         )
 
-        for try await progress in try await download.download(file: fileToDownload) {
-            var text = "\(progress.bytesWritten/1024/1024) MB"
-            text += String(format: " / %.2f MBs", progress.bandwidth)
-            progressBar.update(
-                step: Int(progress.bytesWritten / 1024),
-                total: Int(progress.totalBytes / 1024),
-                text: text
-            )
+        // the progress bar is only started once the stream produces its first update,
+        // so a failure to open the stream leaves nothing to close
+        let progressStream = try await download.download(file: fileToDownload)
+        do {
+            for try await progress in progressStream {
+                var text = "\(progress.bytesWritten/1024/1024) MB"
+                text += String(format: " / %.2f MBs", progress.bandwidth)
+                progressBar.update(
+                    step: Int(progress.bytesWritten / 1024),
+                    total: Int(progress.totalBytes / 1024),
+                    text: text
+                )
+            }
+            progressBar.complete(success: true)
+        } catch {
+            // close the progress bar line, the error itself is reported by the CLI layer
+            progressBar.complete(success: false)
+            throw error
         }
-        progressBar.complete(success: true)
 
         // check if the downloaded file is complete
         let fh = self.deps.fileHandler

--- a/Sources/xcodeinstall/xcodeInstall/InstallCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/InstallCommand.swift
@@ -32,74 +32,34 @@ extension XCodeInstall {
             message: "Installing..."
         )
 
-        var fileToInstall: URL?
         do {
+            let fileToInstall: URL
             // when no file is specified, prompt user to select one
             if nil == file {
                 fileToInstall = try promptForFile()
             } else {
                 fileToInstall = self.deps.fileHandler.downloadDirectory().appendingPathComponent(file!)
             }
-            log.debug("Going to attempt to install \(fileToInstall!.path)")
+            log.debug("Going to attempt to install \(fileToInstall.path)")
 
             // resolve version: CLI flag > auto-extract > prompt user
             let resolvedVersion = try resolveVersion(
                 explicitVersion: version,
-                filename: fileToInstall!.lastPathComponent
+                filename: fileToInstall.lastPathComponent
             )
 
-            try await installer.install(file: fileToInstall!, version: resolvedVersion)
+            try await installer.install(file: fileToInstall, version: resolvedVersion)
             self.deps.progressBar.complete(success: true)
             if let resolvedVersion {
                 display("Xcode \(resolvedVersion) installed and activated", style: .success)
             } else {
-                display("\(fileToInstall!) installed", style: .success)
+                display("\(fileToInstall) installed", style: .success)
             }
         } catch CLIError.userCancelled {
-            return
-        } catch CLIError.invalidInput {
-            display("Invalid input", style: .error())
-            self.deps.progressBar.complete(success: false)
-            throw CLIError.invalidInput
-        } catch FileHandlerError.noDownloadedList {
-            display("There is no downloaded file to be installed", style: .warning)
-            self.deps.progressBar.complete(success: false)
-            throw FileHandlerError.noDownloadedList
-        } catch InstallerError.xCodeXIPInstallationError {
-            display("Can not expand XIP file. Is there enough space on / ? (16GiB required)", style: .error())
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.xCodeXIPInstallationError
-        } catch InstallerError.xCodeMoveInstallationError {
-            display("Can not move Xcode to /Applications", style: .error())
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.xCodeMoveInstallationError
-        } catch InstallerError.xCodePKGInstallationError {
-            display(
-                "Can not install additional packages.",
-                style: .error()
-            )
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.xCodePKGInstallationError
-        } catch InstallerError.existingXcodeAppIsNotSymlink {
-            display(
-                "/Applications/Xcode.app exists and is not a symlink. Please rename or remove it before installing a versioned Xcode.",
-                style: .error()
-            )
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.existingXcodeAppIsNotSymlink
-        } catch InstallerError.xcodeSelectFailed {
-            display("Failed to run xcode-select to activate Xcode", style: .error())
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.xcodeSelectFailed
-        } catch InstallerError.unsupportedInstallation {
-            display(
-                "Unsupported installation type. (We support Xcode XIP files and Command Line Tools PKG)",
-                style: .error()
-            )
-            self.deps.progressBar.complete(success: false)
-            throw InstallerError.unsupportedInstallation
+            // the user interrupted a prompt, the installation never started
+            throw CLIError.userCancelled
         } catch {
-            display("Error while installing \(String(describing: fileToInstall!))", style: .error())
+            // the error itself is reported by the CLI layer, we only close the progress bar
             log.debug("\(error)")
             self.deps.progressBar.complete(success: false)
             throw error

--- a/Sources/xcodeinstall/xcodeInstall/ListCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/ListCommand.swift
@@ -13,6 +13,11 @@ import Foundation
 
 extension XCodeInstall {
 
+    /// Fetches, parses and displays the list of available downloads.
+    ///
+    /// Errors are propagated untouched: they are rendered once by the CLI layer
+    /// (see `ErrorPresenter`). This matters because `download` reuses this method
+    /// through `askFile(...)`.
     func list(
         force: Bool,
         xCodeOnly: Bool,
@@ -25,82 +30,38 @@ extension XCodeInstall {
 
         display("Loading list of available downloads...")
 
-        do {
-            let (list, source) = try await download.list(force: force)
-            switch source {
-            case .cache:
-                display("Fetched from cache in \(self.deps.fileHandler.baseFilePath())", style: .info)
-            case .network:
-                if !force {
-                    display("No cache found, downloaded from Apple Developer Portal", style: .info)
-                } else {
-                    display("Forced download from Apple Developer Portal", style: .info)
-                }
+        let (list, source) = try await download.list(force: force)
+        switch source {
+        case .cache:
+            display("Fetched from cache in \(self.deps.fileHandler.baseFilePath())", style: .info)
+        case .network:
+            if !force {
+                display("No cache found, downloaded from Apple Developer Portal", style: .info)
+            } else {
+                display("Forced download from Apple Developer Portal", style: .info)
             }
-            display("Done", style: .success)
-
-            let parser = DownloadListParser(
-                fileHandler: self.deps.fileHandler,
-                xCodeOnly: xCodeOnly,
-                majorVersion: majorVersion,
-                sortMostRecentFirst: sortMostRecentFirst
-            )
-            let parsedList = try parser.parse(list: list)
-
-            // enrich the list to flag files already downloaded
-            let enrichedList = await parser.enrich(list: parsedList)
-
-            display("")
-            display("Here is the list of available downloads:", style: .info)
-            display("  Files marked with (*) are already downloaded in \(self.deps.fileHandler.baseFilePath()) ")
-            display("")
-            let string = parser.prettyPrint(list: enrichedList, withDate: datePublished)
-            display(string)
-            display("\(enrichedList.count) items")
-
-            return enrichedList
-
-        } catch let error as DownloadError {
-            switch error {
-            case .authenticationRequired:
-                display(
-                    "Session expired, you need to re-authenticate.",
-                    style: .error(nextSteps: ["xcodeinstall authenticate"])
-                )
-                throw error
-            case .accountNeedUpgrade(let code, let message):
-                display("\(message) (Apple Portal error code : \(code))", style: .error())
-                throw error
-            case .needToAcceptTermsAndCondition:
-                display(
-                    """
-                    This is a new Apple account, you need first to accept the developer terms of service.
-                    Open a session at https://developer.apple.com/register/agree/
-                    Read and accept the ToS and try again.
-                    """,
-                    style: .error()
-                )
-                throw error
-            case .unknownError(let code, let message):
-                display("\(message) (Unhandled download error : \(code))", style: .error())
-                display(
-                    "Please file an error report at https://github.com/sebsto/xcodeinstall/issues/new?assignees=&labels=&template=bug_report.md&title="
-                )
-                throw error
-            default:
-                display("Unknown download error : \(error)", style: .error())
-                display(
-                    "Please file an error report at https://github.com/sebsto/xcodeinstall/issues/new?assignees=&labels=&template=bug_report.md&title="
-                )
-                throw error
-            }
-        } catch let error as SecretsStorageAWSError {
-            display("AWS Error: \(error.localizedDescription)", style: .error())
-            throw error
-        } catch {
-            display("Unexpected error : \(error)", style: .error())
-            throw error
         }
+        display("Done", style: .success)
 
+        let parser = DownloadListParser(
+            fileHandler: self.deps.fileHandler,
+            xCodeOnly: xCodeOnly,
+            majorVersion: majorVersion,
+            sortMostRecentFirst: sortMostRecentFirst
+        )
+        let parsedList = try parser.parse(list: list)
+
+        // enrich the list to flag files already downloaded
+        let enrichedList = await parser.enrich(list: parsedList)
+
+        display("")
+        display("Here is the list of available downloads:", style: .info)
+        display("  Files marked with (*) are already downloaded in \(self.deps.fileHandler.baseFilePath()) ")
+        display("")
+        let string = parser.prettyPrint(list: enrichedList, withDate: datePublished)
+        display(string)
+        display("\(enrichedList.count) items")
+
+        return enrichedList
     }
 }

--- a/Sources/xcodeinstall/xcodeInstall/SignOutCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/SignOutCommand.swift
@@ -17,17 +17,8 @@ extension XCodeInstall {
 
         let auth = self.deps.authenticator
 
-        do {
-            display("Signing out...")
-            try await auth.signout()
-            display("Signed out.", style: .success)
-        } catch let error as SecretsStorageAWSError {
-            display("AWS Error: \(error.localizedDescription)", style: .error())
-            throw error
-        } catch {
-            display("Unexpected error : \(error)", style: .error())
-            throw error
-        }
-
+        display("Signing out...")
+        try await auth.signout()
+        display("Signed out.", style: .success)
     }
 }

--- a/Sources/xcodeinstall/xcodeInstall/StoreSecretsCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/StoreSecretsCommand.swift
@@ -18,21 +18,12 @@ extension XCodeInstall {
         guard let secretsHandler = self.deps.secrets else {
             preconditionFailure("storeSecrets() called without a secrets backend — this is a programming error")
         }
-        do {
-            // separate func for testability
-            let credentials = try promptForCredentials()
 
-            try await secretsHandler.storeAppleCredentials(credentials)
-            display("Credentials are securely stored", style: .security)
+        // separate func for testability
+        let credentials = try promptForCredentials()
 
-        } catch let error as SecretsStorageAWSError {
-            display("AWS Error: \(error.localizedDescription)", style: .error())
-            throw error
-        } catch {
-            display("Unexpected error : \(error)", style: .error())
-            throw error
-        }
-
+        try await secretsHandler.storeAppleCredentials(credentials)
+        display("Credentials are securely stored", style: .security)
     }
 
     func promptForCredentials() throws -> AppleCredentialsSecret {

--- a/Sources/xcodeinstall/xcodeInstall/SwitchCommand.swift
+++ b/Sources/xcodeinstall/xcodeInstall/SwitchCommand.swift
@@ -12,12 +12,12 @@ extension XCodeInstall {
         do {
             installed = try self.deps.fileHandler.listInstalledXcodes()
         } catch {
-            display("Failed to list installed Xcode versions", style: .error())
-            throw error
+            // the underlying error carries no information for the user
+            log.debug("\(error)")
+            throw InstallerError.unableToListInstalledXcodes
         }
 
-        if installed.isEmpty {
-            display("No versioned Xcode installations found in /Applications", style: .warning)
+        guard !installed.isEmpty else {
             throw InstallerError.noInstalledXcodeVersions
         }
 
@@ -30,7 +30,6 @@ extension XCodeInstall {
 
         let targetApp = "Xcode-\(targetVersion).app"
         guard installed.contains(targetApp) else {
-            display("Xcode \(targetVersion) is not installed in /Applications", style: .error())
             throw InstallerError.xcodeVersionNotInstalled(targetVersion)
         }
 

--- a/Tests/xcodeinstallTests/CLI/CLIAuthTest.swift
+++ b/Tests/xcodeinstallTests/CLI/CLIAuthTest.swift
@@ -90,10 +90,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: AuthenticationError.self) {
-            _ = try parse(MainCommand.Authenticate.self, ["authenticate"])
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         assertDisplay(env: env, "Invalid username or password.")
@@ -143,9 +142,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: AuthenticationError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // username and password consumed by delegate.requestCredentials()
@@ -167,11 +166,11 @@ extension CLITests {
             SecretsStorageAWSError.invalidRegion(region: "bad-region")
 
         let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: SecretsStorageAWSError.self) {
-            try await xci.signout()
+        await #expect(throws: ExitCode.self) {
+            let signout = try parse(MainCommand.Signout.self, ["signout"])
+            try await signout.run(with: deps)
         }
 
         // then — verify the AWS Error message was displayed
@@ -187,11 +186,11 @@ extension CLITests {
         (env.authenticator as! MockedAppleAuthentication).nextSignoutError = MockError.genericTestError
 
         let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: MockError.self) {
-            try await xci.signout()
+        await #expect(throws: ExitCode.self) {
+            let signout = try parse(MainCommand.Signout.self, ["signout"])
+            try await signout.run(with: deps)
         }
 
         // then — verify the Unexpected error message was displayed
@@ -208,9 +207,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: AuthenticationError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // then
@@ -226,9 +225,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: AuthenticationError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // then
@@ -245,9 +244,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: AuthenticationError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // then
@@ -264,9 +263,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: SecretsStorageAWSError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // then
@@ -281,13 +280,13 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: MockError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.authenticate(with: AuthenticationMethod.withSRP(false))
+        await #expect(throws: ExitCode.self) {
+            let auth = try parse(MainCommand.Authenticate.self, ["authenticate", "--srp", "false"])
+            try await auth.run(with: deps)
         }
 
         // then
-        assertDisplayContains(env: env, "Unexpected Error")
+        assertDisplayContains(env: env, "Unexpected error")
     }
 
     @Test("Test Authenticate With Username Password Method")

--- a/Tests/xcodeinstallTests/CLI/CLIDownloadTest.swift
+++ b/Tests/xcodeinstallTests/CLI/CLIDownloadTest.swift
@@ -161,20 +161,33 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: DownloadError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: fileName,
-                force: false,
-                xCodeOnly: false,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(MainCommand.Download.self, ["download", "--name", fileName])
+            try await download.run(with: deps)
         }
 
         // then
         assertDisplayStartsWith("Session expired")
+    }
+
+    @Test("Test Download reports an expired session only once")
+    func testDownloadAuthenticationRequiredReportedOnce() async throws {
+
+        // given — no --name, so download asks the list for the available files
+        let env = MockedEnvironment()
+        env.downloader.nextListError = DownloadError.authenticationRequired
+
+        let deps = env.toDeps(log: log)
+
+        // when
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(MainCommand.Download.self, ["download", "--only-xcode"])
+            try await download.run(with: deps)
+        }
+
+        // then — the error travels through list() and download(), yet is rendered once
+        let messages = (env.display as! MockedDisplay).allMessages
+        #expect(messages.filter({ $0.contains("Session expired") }).count == 1)
     }
 
     @Test("Test Download user cancelled")
@@ -189,18 +202,18 @@ extension CLITests {
 
         let deps = env.toDeps(log: log)
 
-        // when - userCancelled is caught silently with return, no error thrown
+        // when - a cancellation exits successfully and reports nothing
         await #expect(throws: Never.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: nil,
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
+            let download = try parse(
+                MainCommand.Download.self,
+                ["download", "--only-xcode", "--xcode-version", "14"]
             )
+            try await download.run(with: deps)
         }
+
+        // then
+        let messages = (env.display as! MockedDisplay).allMessages
+        #expect(!messages.contains(where: { $0.contains("Invalid input") }))
     }
 
     @Test("Test Download invalid input")
@@ -216,16 +229,12 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: CLIError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: nil,
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(
+                MainCommand.Download.self,
+                ["download", "--only-xcode", "--xcode-version", "14"]
             )
+            try await download.run(with: deps)
         }
 
         // then
@@ -241,16 +250,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: SecretsStorageAWSError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: "Xcode 14.xip",
-                force: false,
-                xCodeOnly: false,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(MainCommand.Download.self, ["download", "--name", "Xcode 14.xip"])
+            try await download.run(with: deps)
         }
 
         // then
@@ -266,16 +268,9 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: Error.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: "Xcode 14.xip",
-                force: false,
-                xCodeOnly: false,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(MainCommand.Download.self, ["download", "--name", "Xcode 14.xip"])
+            try await download.run(with: deps)
         }
 
         // then
@@ -295,16 +290,12 @@ extension CLITests {
         let deps = env.toDeps(log: log)
 
         // when
-        await #expect(throws: CLIError.self) {
-            let xci = XCodeInstall(log: log, deps: deps)
-            try await xci.download(
-                fileName: nil,
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
+        await #expect(throws: ExitCode.self) {
+            let download = try parse(
+                MainCommand.Download.self,
+                ["download", "--only-xcode", "--xcode-version", "14"]
             )
+            try await download.run(with: deps)
         }
 
         // then

--- a/Tests/xcodeinstallTests/CLI/CLIInstallTest.swift
+++ b/Tests/xcodeinstallTests/CLI/CLIInstallTest.swift
@@ -77,11 +77,11 @@ extension CLITests {
         )
         (env.fileHandler as! MockedFileHandler).nextDownloadedFilesError = FileHandlerError.noDownloadedList
         let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
-        // when (file: nil triggers promptForFile which calls downloadedFiles())
-        await #expect(throws: FileHandlerError.self) {
-            try await xci.install(file: nil)
+        // when (no name triggers promptForFile which calls downloadedFiles())
+        await #expect(throws: ExitCode.self) {
+            let inst = try parse(MainCommand.Install.self, ["install"])
+            try await inst.run(with: deps)
         }
 
         // then
@@ -137,11 +137,11 @@ extension CLITests {
         // given
         let env: MockedEnvironment = MockedEnvironment(progressBar: MockedProgressBar())
         let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when (test.txt is not a supported installation type)
-        await #expect(throws: InstallerError.self) {
-            try await xci.install(file: "test.txt")
+        await #expect(throws: ExitCode.self) {
+            let inst = try parse(MainCommand.Install.self, ["install", "--name", "test.txt"])
+            try await inst.run(with: deps)
         }
 
         // then
@@ -156,16 +156,19 @@ extension CLITests {
         // configure the shell to throw a generic error
         env.shell.nextError = MockError.invalidMockData
         let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when (Command Line Tools dmg file is a supported type, fileExists returns true by default,
         // but the shell will throw when trying to mount the DMG)
-        await #expect(throws: MockError.self) {
-            try await xci.install(file: "Command Line Tools for Xcode 14.dmg")
+        await #expect(throws: ExitCode.self) {
+            let inst = try parse(
+                MainCommand.Install.self,
+                ["install", "--name", "Command Line Tools for Xcode 14.dmg"]
+            )
+            try await inst.run(with: deps)
         }
 
         // then
-        assertDisplayStartsWith(env: env, "Error while installing")
+        assertDisplayStartsWith(env: env, "Unexpected error")
     }
 
 }

--- a/Tests/xcodeinstallTests/CLI/CLIListTest.swift
+++ b/Tests/xcodeinstallTests/CLI/CLIListTest.swift
@@ -5,6 +5,7 @@
 //  Created by Stormacq, Sebastien on 22/08/2022.
 //
 
+import ArgumentParser
 import Foundation
 import Testing
 
@@ -50,25 +51,27 @@ extension CLITests {
     }
 
     // MARK: - List Error Path Tests
+    // errors are rendered by the CLI layer, so these run the command end to end
+
+    /// Runs `xcodeinstall list` against a downloader that fails with `error`.
+    private func runListExpectingFailure(
+        _ error: Error,
+        in env: MockedEnvironment
+    ) async throws {
+        env.downloader.nextListError = error
+        let deps = env.toDeps(log: log)
+        let list = try parse(MainCommand.List.self, ["list", "--only-xcode", "--xcode-version", "14"])
+
+        await #expect(throws: ExitCode.self) { try await list.run(with: deps) }
+    }
 
     @Test("Test List Authentication Required")
     func testListAuthenticationRequired() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = DownloadError.authenticationRequired
-        let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: DownloadError.self) {
-            try await xci.list(
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
-        }
+        try await runListExpectingFailure(DownloadError.authenticationRequired, in: env)
 
         // then
         assertDisplayContains(env: env, "Session expired")
@@ -78,20 +81,12 @@ extension CLITests {
     func testListAccountNeedUpgrade() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = DownloadError.accountNeedUpgrade(errorCode: 2170, errorMessage: "upgrade needed")
-        let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: DownloadError.self) {
-            try await xci.list(
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
-        }
+        try await runListExpectingFailure(
+            DownloadError.accountNeedUpgrade(errorCode: 2170, errorMessage: "upgrade needed"),
+            in: env
+        )
 
         // then
         assertDisplayContains(env: env, "upgrade needed")
@@ -102,20 +97,9 @@ extension CLITests {
     func testListNeedToAcceptTermsAndCondition() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = DownloadError.needToAcceptTermsAndCondition
-        let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: DownloadError.self) {
-            try await xci.list(
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
-        }
+        try await runListExpectingFailure(DownloadError.needToAcceptTermsAndCondition, in: env)
 
         // then
         assertDisplayContains(env: env, "you need first to accept")
@@ -125,20 +109,12 @@ extension CLITests {
     func testListUnknownError() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = DownloadError.unknownError(errorCode: 9999, errorMessage: "Something broke")
-        let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: DownloadError.self) {
-            try await xci.list(
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
-        }
+        try await runListExpectingFailure(
+            DownloadError.unknownError(errorCode: 9999, errorMessage: "Something broke"),
+            in: env
+        )
 
         // then
         assertDisplayContains(env: env, "Unhandled download error")
@@ -148,20 +124,9 @@ extension CLITests {
     func testListSecretsStorageAWSError() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = SecretsStorageAWSError.invalidRegion(region: "bad-region")
-        let deps = env.toDeps(log: log)
-        let xci = XCodeInstall(log: log, deps: deps)
 
         // when
-        await #expect(throws: SecretsStorageAWSError.self) {
-            try await xci.list(
-                force: false,
-                xCodeOnly: true,
-                majorVersion: "14",
-                sortMostRecentFirst: false,
-                datePublished: false
-            )
-        }
+        try await runListExpectingFailure(SecretsStorageAWSError.invalidRegion(region: "bad-region"), in: env)
 
         // then
         assertDisplayContains(env: env, "AWS Error")
@@ -171,13 +136,25 @@ extension CLITests {
     func testListUnexpectedError() async throws {
         // given
         let env = MockedEnvironment()
-        env.downloader.nextListError = MockError.genericTestError
+
+        // when
+        try await runListExpectingFailure(MockError.genericTestError, in: env)
+
+        // then
+        assertDisplayContains(env: env, "Unexpected error")
+    }
+
+    @Test("Test List propagates the error to its caller")
+    func testListPropagatesError() async throws {
+        // given
+        let env = MockedEnvironment()
+        env.downloader.nextListError = DownloadError.authenticationRequired
         let deps = env.toDeps(log: log)
         let xci = XCodeInstall(log: log, deps: deps)
 
-        // when
-        await #expect(throws: MockError.self) {
-            try await xci.list(
+        // when — the business layer throws without displaying anything
+        await #expect(throws: DownloadError.authenticationRequired) {
+            _ = try await xci.list(
                 force: false,
                 xCodeOnly: true,
                 majorVersion: "14",
@@ -187,7 +164,8 @@ extension CLITests {
         }
 
         // then
-        assertDisplayContains(env: env, "Unexpected error")
+        let messages = (env.display as! MockedDisplay).allMessages
+        #expect(!messages.contains(where: { $0.contains("Session expired") }))
     }
 
     @Test("Test List From Network Forced")


### PR DESCRIPTION
## Problem

`xcodeinstall download` reported an expired session twice:

```
✖ Error
  Session expired, you need to re-authenticate.

  Sorry this didn’t work. Here’s what to try next:
   ▸ xcodeinstall authenticate
✖ Error
  Session expired, you need to re-authenticate.

  Sorry this didn’t work. Here’s what to try next:
   ▸ xcodeinstall authenticate
```

Both `XCodeInstall.list` and `XCodeInstall.download` caught `DownloadError.authenticationRequired`, displayed it, and rethrew it. `download` reaches the interactive picker through `askFile` → `list`, so the error passed through both catch blocks and Noora rendered the alert twice. The same duplication applied to `SecretsStorageAWSError` and to any unexpected error surfacing through `askFile`.

## Change

Error presentation moves to the CLI layer, leaving business logic to throw.

- **`ErrorPresenter`** maps any `Error` to the messages and styles the user sees, and to whether the process fails. It is the only place that copy lives. `CLIError.userCancelled` maps to a silent, successful outcome.
- **`MainCommand.run(on:_:)`** wraps each subcommand body, renders the presentation once on `xci.deps.display`, shuts the AWS client down, and maps to an exit code. **`MainCommand.makeXCodeInstall`** does the same for construction failures, replacing seven copies of the same catch block.
- The `XCodeInstall` layer no longer displays errors. `install` keeps a catch solely to close its progress bar, and rethrows without displaying.

Net 570 lines removed, 296 added, plus ~280 in the two new files.

## Behavior changes beyond the fix

These follow from having one set of messages instead of six:

- `install`'s generic failure was `Error while installing <file>` and hid the underlying error. It now reads `Unexpected error : <error>`, consistent with the other commands.
- `authenticate`'s `Unexpected Error` is lowercased to match everywhere else.
- `switchVersion` throws a new `InstallerError.unableToListInstalledXcodes` instead of printing the message itself. The text is unchanged; the underlying error goes to the debug log.
- `install` and `switch` now shut the secrets client down on exit, which they previously skipped.
- Construction errors go through the presenter, so an AWS failure there gains the `AWS Error: ` prefix.

## Testing

`swift build` is clean with no warnings. `swift test` passes 205 tests.

The 24 error-path tests that asserted display output from the business layer now drive the actual ArgumentParser subcommand, so they cover the real rendering path and the `ExitCode.failure` mapping rather than an intermediate layer. Two tests were added:

- `list` throws without displaying anything.
- a session expiry reaching `download` through `list` is rendered exactly once.

Running the built binary against a real expired session reproduced the original report and printed the block once.

**Not verified:** the exit code of the real binary. A follow-up run to check it hung with no output during AWS SSO credential resolution for the configured profile, a path this change does not touch. The exit code is covered by the tests.
